### PR TITLE
Fixes to make library buildable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,11 @@
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+      classpath 'com.android.tools.build:gradle:1.5.0'
+    }
+}
 apply plugin: 'com.android.library'
 
 android {
@@ -17,6 +25,10 @@ android {
         }
     }
 
+}
+
+repositories {
+  jcenter()
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,10 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion 23
     buildToolsVersion "23.0.2"
+    
+    lintOptions {
+          abortOnError false
+    }
 
     defaultConfig {
         minSdkVersion 14


### PR DESCRIPTION
Adding these to be able to build the library:
- maven repository
- android plugin classpath
- turning off lint abort on error

Without those, gradle will refuse to build.
